### PR TITLE
ETag header should be enclosed in quotes.

### DIFF
--- a/app/src/main/java/org/qosp/notes/data/sync/nextcloud/NextcloudAPI.kt
+++ b/app/src/main/java/org/qosp/notes/data/sync/nextcloud/NextcloudAPI.kt
@@ -91,7 +91,7 @@ suspend fun NextcloudAPI.updateNote(note: NextcloudNote, etag: String, config: N
     return updateNoteAPI(
         note = note,
         url = config.remoteAddress + baseURL + "notes/${note.id}",
-        etag = etag,
+        etag = "\"$etag\"",
         auth = config.credentials,
     )
 }

--- a/app/src/main/java/org/qosp/notes/di/NextcloudModule.kt
+++ b/app/src/main/java/org/qosp/notes/di/NextcloudModule.kt
@@ -6,7 +6,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import org.qosp.notes.data.repo.IdMappingRepository
 import org.qosp.notes.data.repo.NoteRepository
 import org.qosp.notes.data.repo.NotebookRepository
@@ -30,7 +30,7 @@ object NextcloudModule {
                 Json {
                     ignoreUnknownKeys = true
                 }
-                    .asConverterFactory(MediaType.get("application/json"))
+                    .asConverterFactory("application/json".toMediaType())
             )
             .build()
             .create()


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag

The Nextcloud implementation expects the ETag to have quotes and the quillnote does not send the quotes. Because of this, the server is not able to find the note we're trying to update and rejects the update. Details at https://github.com/nextcloud/notes/pull/883

This should fix #179